### PR TITLE
libseat: unbreak on FreeBSD

### DIFF
--- a/.builds/freebsd.yml
+++ b/.builds/freebsd.yml
@@ -11,6 +11,7 @@ packages:
 - graphics/wayland
 - graphics/wayland-protocols
 - multimedia/ffmpeg
+- sysutils/seatd
 - x11/libX11
 - x11/libinput
 - x11/libxcb

--- a/backend/session/direct-freebsd.c
+++ b/backend/session/direct-freebsd.c
@@ -39,8 +39,9 @@ static struct direct_session *direct_session_from_session(
 	return (struct direct_session *)base;
 }
 
-static int direct_session_open(struct wlr_session *base, const char *path) {
+static int direct_session_open(struct wlr_session *base, const char *path, int *device_id) {
 	struct direct_session *session = direct_session_from_session(base);
+	(void)device_id;
 
 	int fd = direct_ipc_open(session->sock, path);
 	if (fd < 0) {
@@ -52,8 +53,9 @@ static int direct_session_open(struct wlr_session *base, const char *path) {
 	return fd;
 }
 
-static void direct_session_close(struct wlr_session *base, int fd) {
+static void direct_session_close(struct wlr_session *base, int fd, int device_id) {
 	struct direct_session *session = direct_session_from_session(base);
+	(void)device_id;
 
 	int ev;
 	struct drm_version dv = {0};

--- a/backend/session/libseat.c
+++ b/backend/session/libseat.c
@@ -1,13 +1,11 @@
 #define _POSIX_C_SOURCE 200809L
 #include <assert.h>
 #include <errno.h>
-#include <fcntl.h>
 #include <stdbool.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <sys/stat.h>
-#include <sys/sysmacros.h>
 #include <unistd.h>
 #include <wayland-server-core.h>
 #include <wlr/backend/session/interface.h>


### PR DESCRIPTION
CI would still fail as binary package hasn't been built yet.