### PR TITLE
libseat: drop unused "path" from struct wlr_drm_backend

### DIFF
--- a/include/backend/drm/drm.h
+++ b/include/backend/drm/drm.h
@@ -82,7 +82,6 @@ struct wlr_drm_backend {
 	bool addfb2_modifiers;
 
 	int fd;
-	const char *path;
 
 	size_t num_crtcs;
 	struct wlr_drm_crtc *crtcs;


### PR DESCRIPTION
```
$ rg path backend/drm
backend/drm/properties.c
25:     { "PATH", INDEX(path) },

backend/drm/drm.c
1397:                   size_t path_len;
1399:                   char *path = get_drm_prop_blob(drm->fd, wlr_conn->id,
1400:                           wlr_conn->props.path, &path_len);
1401:                   if (path && path_len > 4 && strncmp(path, "mst:", 4) == 0) {
1404:                   free(path);
```
